### PR TITLE
🐛 Fix timeZone in logs

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,8 @@
     "dbName": "LOG_DB",
     "isEnable": true,
     "hasConsoleOutput": true,
-    "frequency": 1
+    "frequency": 1,
+    "timeZone": "Europe/Moscow"
   },
   "sender": {
     "host": "172.17.0.1",

--- a/logger.ts
+++ b/logger.ts
@@ -1,4 +1,5 @@
 import { TMessage } from './types';
+import config from './config.json';
 
 export enum ELogLevel {
   ALL = 'ALL',
@@ -20,6 +21,7 @@ const formatter = new Intl.DateTimeFormat('ru', {
   hour: '2-digit',
   minute: '2-digit',
   second: '2-digit',
+  timeZone: config.log.timeZone,
 });
 
 export class Logger {


### PR DESCRIPTION
## Now we can use specified timezone for log messages instead of locale zone of machine